### PR TITLE
Update getting-an-access-token-for-sap-cloud-management-service-apis-…

### DIFF
--- a/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
+++ b/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
@@ -161,15 +161,15 @@ Your global account admin has entitled at least SAP ONE Service service plan fro
     >  "grant_type": "user_token",
     >  "uaa": {
     >   ...
-    >   "clientid": <client_id>,
-    >   "clientsecret": <client_secret>,
+    >   "clientid": <clientid>,
+    >   "clientsecret": <clientsecret>,
     >   "url": <uaa_url>,
     >   ...
     >  }
     > }
     > ```
 
-3.  Use the `uaa.url`, `uaa.clientid`, and `uaa.clientsecret` to request an access token using the following commands:
+3.  Use the `uaa_url`, `clientid`, and `clientsecret` to request an access token using the following commands:
 
     > ### Sample Code:  
     > For Windows OS \(Password grant type\):

--- a/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
+++ b/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
@@ -169,7 +169,7 @@ Your global account admin has entitled at least SAP ONE Service service plan fro
     > }
     > ```
 
-3.  Use the `uaa_url`, `clientid`, and `clientsecret` to request an access token using the following commands:
+3.  Use the `uaa.url`, `uaa.clientid`, and `uaa.clientsecret` to request an access token using the following commands:
 
     > ### Sample Code:  
     > For Windows OS \(Password grant type\):

--- a/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
+++ b/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
@@ -199,10 +199,10 @@ Your global account admin has entitled at least SAP ONE Service service plan fro
     > For Mac OS \(Password grant type\):
     > 
     > ```
-    > curl -L -X POST '*<uaa\_url\>*/oauth/token' \ 
-    > -H 'Content-Type: application/x-www-form-urlencoded' \ 
-    > -u '*<clientid\>*:*<clientsecret\>*' \ 
-    > -d 'grant_type=password' \ 
+    > curl -L -X POST '*<uaa\_url\>*/oauth/token' \
+    > -H 'Content-Type: application/x-www-form-urlencoded' \
+    > -u '*<clientid\>*:*<clientsecret\>*' \
+    > -d 'grant_type=password' \
     > -d 'username=*<user email\>*' \
     > -d 'password=*<password\>*'
     > 
@@ -212,10 +212,10 @@ Your global account admin has entitled at least SAP ONE Service service plan fro
     > For Mac OS \(Client Credentials grant type\):
     > 
     > ```
-    > curl -L -X POST '*<uaa\_url\>*/oauth/token' \ 
-    > -H 'Content-Type: application/x-www-form-urlencoded' \ 
-    > -u '*<clientid\>*:*<clientsecret\>*' \ 
-    > -d 'grant_type=client_credentials' \ 
+    > curl -L -X POST '*<uaa\_url\>*/oauth/token' \
+    > -H 'Content-Type: application/x-www-form-urlencoded' \
+    > -u '*<clientid\>*:*<clientsecret\>*' \
+    > -d 'grant_type=client_credentials'
     > 
     > ```
 

--- a/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
+++ b/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
@@ -2,11 +2,11 @@
 
 # Getting an Access Token for SAP Cloud Management Service APIs
 
-The APIs of the SAP Cloud Management service for SAP BTP are protected with the OAuth 2.0 Password grant and, in some cases, also the Client Credentials grant type. This procedure guides you through the steps to create an OAuth client and obtain an access token from SAP Authorization and Trust Management service \(`xsuaa`\) to call the APIs of the SAP Cloud Management service.
+The APIs of the SAP Cloud Management service for SAP BTP are protected with the OAuth 2.0 Password grant type, and, in some cases, also the Client Credentials grant type. This procedure guides you through the steps to create an OAuth client and obtain an access token from SAP Authorization and Trust Management service \(`xsuaa`\) to call the APIs of the SAP Cloud Management service.
 
 
 
-The Client Credentials grant type is currently available for the SAP Cloud Management service only when creating the instances of this service on a subaccount level by using SAP Service Manager API, CLI, or when creating an instance of an SAPSAP Cloud Management service using the SAP BTP cockpit.
+The Client Credentials grant type is currently available for the SAP Cloud Management service only when creating the instances of this service on a subaccount level by using the SAP Service Manager API, the Service Manager Control (SMCTL) CLI, or when creating an instance of an SAP Cloud Management service using the SAP BTP cockpit.
 
 For more information, see [Consuming Services in Other Environments Using the Service Management Instances](https://help.sap.com/viewer/09cc82baadc542a688176dce601398de/Cloud/en-US/0714ac254e83492281d95e25548b388c.html).
 
@@ -118,7 +118,7 @@ Your global account admin has entitled at least SAP ONE Service service plan fro
         For more information about the APIs, see the `Subaccount Operations` section of the `Accounts` service in the [SAP API Business Hub](https://api.sap.com/api/APIAccountsService/resource) 
 
         > ### Note:  
-        > If you use the SAP Service Manager API, CLI, or SAP BTP cockpit to create the service instance of the SAP Cloud Management service \(`cis`\), you can get a Client Credentials grant type token by specifying the following parameter during the instance creation: `{"grantType": "clientCredentials"}`.
+        > If you use the SAP Service Manager API, the Service Manager Control (SMCTL) CLI, or the SAP BTP cockpit to create the service instance of the SAP Cloud Management service \(`cis`\), you can get a Client Credentials grant type token by specifying the following parameter during the instance creation: `{"grantType": "clientCredentials"}`.
         > 
         > If you don't specify this parameter, the Password grant type is chosen by default.
 

--- a/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
+++ b/docs/50-administration-and-ops/getting-an-access-token-for-sap-cloud-management-service-apis-3670474.md
@@ -178,9 +178,9 @@ Your global account admin has entitled at least SAP ONE Service service plan fro
     > curl -L -X POST "*<uaa\_url\>*/oauth/token" ^ 
     > -H "Content-Type: application/x-www-form-urlencoded" ^ 
     > -u "*<clientid\>*:*<clientsecret\>*" ^ 
-    > -d "grant_type=password" ^ 
-    > -d "username=*<user email\>*" ^ 
-    > -d "password=*<password\>*" 
+    > --data-urlencode "grant_type=password" ^ 
+    > --data-urlencode "username=*<user email\>*" ^ 
+    > --data-urlencode "password=*<password\>*" 
     > 
     > ```
 
@@ -202,9 +202,9 @@ Your global account admin has entitled at least SAP ONE Service service plan fro
     > curl -L -X POST '*<uaa\_url\>*/oauth/token' \
     > -H 'Content-Type: application/x-www-form-urlencoded' \
     > -u '*<clientid\>*:*<clientsecret\>*' \
-    > -d 'grant_type=password' \
-    > -d 'username=*<user email\>*' \
-    > -d 'password=*<password\>*'
+    > --data-urlencode 'grant_type=password' \
+    > --data-urlencode 'username=*<user email\>*' \
+    > --data-urlencode 'password=*<password\>*'
     > 
     > ```
 


### PR DESCRIPTION
…3670474.md

An attempt at some minor improvements in readability

* the OAuth "thing" is a grant type, not a grant
* added the definitive article before "SAP Service Manager API" to make it more readable
* expanded on the single "CLI" word to clarify what is meant (in two places) (please correct me if I'm wrong here!) 
* removed a duplicate "SAP"
* make `clientid` and `clientsecret` references consistent
* fix the issues with the Mac OS code samples