### PR TITLE
Amendment suggestions to API calls in the XSUAA service sections

### DIFF
--- a/docs/50-administration-and-ops/access-uaa-admin-apis-ebc9113.md
+++ b/docs/50-administration-and-ops/access-uaa-admin-apis-ebc9113.md
@@ -103,23 +103,24 @@ For more information about the available APIs, see [https://api.sap.com/package/
     > }
     > ```
 
-    With the URL, client ID, and client secret, you can get the access token. With the access token and the ***apiurl***, you have access to the API.
+    With the URL, client ID, and client secret, you can request an access token. With the access token and the ***apiurl***, you have access to the API.
 
-5.  Configure or program your application to get a token from the OAuth client.
+5.  Configure or program your application to request a token from the authorization server, using values of properties in this service key.
 
-    In your call to the OAuth client, you send the client ID and client secret, separated with a colon \(:\) and base64 encoded to the URL from the service key.
+    The token endpoint on the authorization server is made up from the value of the `url` property appended with `/oauth/token`. You authenticate this request with the value of the `clientid` and `clientsecret` properties, separated with a colon, with the `--user` parameter:
 
     > ### Sample Code:  
     > ```
-    > curl --request POST \
-    >   --url https://my-subdomain.authentication.eu10.hana.ondemand.com/oauth/token \
+    > curl \
+    >   --url '<url>/oauth/token' \
     >   --header 'Accept: application/json' \
-    >   --header 'Authorization: Basic eW91ckNsaWVudElEOnlvdXJDbGllbnRTZWNyZXQ' \
     >   --header 'cache-control: no-cache' \
-    >   --data 'grant_type=client_credentials&response_type=token'
+    >   --user '<clientid>:<clientsecret>' \
+    >   --data 'grant_type=client_credentials' \
+    >   --data 'response_type=token'
     > ```
 
-    The client returns a token.
+    The authorization server returns a token along with other related information.
 
     > ### Output Code:  
     > ```json
@@ -131,7 +132,7 @@ For more information about the available APIs, see [https://api.sap.com/package/
     > "jti":"be340353ac694b4cb504c6823f938647"}
     > ```
 
-6.  Use the value of the parameter `access_token` to make calls to the various API endpoints. For an example, see [Call an API](call-an-api-764abf2.md).
+6.  Use the value of the `access_token` property to make calls to the various API endpoints. For an example, see [Call an API](call-an-api-764abf2.md).
 
 
 **Related Information**  

--- a/docs/50-administration-and-ops/call-an-api-764abf2.md
+++ b/docs/50-administration-and-ops/call-an-api-764abf2.md
@@ -19,13 +19,13 @@ To call an API of the Authorization and Trust Management Service you need to obt
 
 ## Procedure
 
-1.  Call the roles endpoint of the authorization API.
+1.  Authenticate a call to an API endpoint of the authorization API using the access token previously obtained as the value for a Bearer type token in an `Authorization` header.
 
     > ### Sample Code:  
     > In this example, we request the list of roles of an XSUAA configuration.
     > 
     > ```
-    > curl --request GET \
+    > curl \
     >   --url https://api.authentication.eu10.hana.ondemand.com/sap/rest/authorization/v2/roles \
     >   --header 'Accept: application/json' \
     >   --header 'Authorization: bearer eyJhbGciOiJSUzI1N...' \
@@ -40,7 +40,7 @@ To call an API of the Authorization and Trust Management Service you need to obt
 
 ## Results
 
-The client returns the list of roles.
+A list of roles is returned.
 
 > ### Output Code:  
 > ```json


### PR DESCRIPTION
Some minor amendment suggestions to improve the `curl` example in the [Access UAA Admin APIs](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/ebc9113a520e495ea5fb759b9a7929f2.html?locale=en-US) section. 

Section 4
- remind the reader that they're actually 'requesting' a token rather than just expecting to get one

Section 5
- it's not a call to the OAuth client, it's to the OAuth token endpoint on the authorization server
- make it clear that the URL is the value of `url` property in the service key with `/oauth/token` appended
- If the suggestion is to use `curl`, which is great, why get the user to go through the ceremony of concatenating two values and then base64 encoding them for an Authorization header; instead, one can just use the `--user` parameter and get `curl` to do that for you. Base64 is just an encoding anyway, there's no security in it per se
- the `--request` parameter is not needed if a `--data` parameter is used in the call to `curl`: by default, the request method is set to `POST` in such cases
- it is perhaps good practice, at least in such contexts as documentation, to make the query parameters and values easier to read by supplying them in separate `--data` parameters (`curl` will automatically join them with `&` symbols when making the request)

One question:
- is the Cache-Control header really required here? 

Section 6
- properties in JSON are not called parameters, it's either 'property' or 'key'

In addition, some further improvements to the next section [Call an API](https://help.sap.com/docs/BTP/65de2977205c403bbc107264b8eccf4b/764abf29f7624e39ad872f86cbd08fa9.html?locale=en-US):

In section 1:

- the *procedure* isn't specifically to call the roles endpoint, that's just an example; the procedure is to make the call (to whatever endpoint you want) and authenticate the call with the access token. The roles example is an instance of this which comes next
- it's worth being explicit about how the access token is to be used ("Bearer", etc)
- the GET method is default with `curl` (unless `--data` is used, for example); the `--request` parameter here is superfluous
- the `application/x-www-form-urlencoded` content type is default with `curl`, so the `Content-Type` header parameter is superfluous
- in the "results" section, it's not the client that returns the roles, it's the server

Question:
- is the cache control header really required here? If it is, and it should remain, at least let's have it written consistently with the other header parameters (i.e. `Cache-Control` rather than `cache-control`)