### PR TITLE
Hint about new default node js version in buildpack

### DIFF
--- a/docs/30-development/developing-node-js-in-the-cloud-foundry-environment-3a7a0be.md
+++ b/docs/30-development/developing-node-js-in-the-cloud-foundry-environment-3a7a0be.md
@@ -57,7 +57,7 @@ The SAP `nodejs_buildpack` supports the following versions:
 
 -   Node.js **14** – recommended version
 -   Node.js **16** – supported but not recommended to use, due to current issues with the *@sap/xsjs* library. Therefore, if you use this library, bear in mind that it will be incompatible with the Node.js 16 runtime.
--   Node.js **18** – default version starting with [version 1.8.4 of the buildpack](https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v1.8.4)
+-   Node.js **18** – default version starting with [version 1.8.4 of the buildpack](https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v1.8.4).
 
 
 <a name="loio3a7a0bece0d044eca59495965d8a0237__section_o5d_4t1_krb"/>

--- a/docs/30-development/developing-node-js-in-the-cloud-foundry-environment-3a7a0be.md
+++ b/docs/30-development/developing-node-js-in-the-cloud-foundry-environment-3a7a0be.md
@@ -57,7 +57,7 @@ The SAP `nodejs_buildpack` supports the following versions:
 
 -   Node.js **14** – recommended version
 -   Node.js **16** – supported but not recommended to use, due to current issues with the *@sap/xsjs* library. Therefore, if you use this library, bear in mind that it will be incompatible with the Node.js 16 runtime.
-
+-   Node.js **18** – default version starting with [version 1.8.4 of the buildpack](https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v1.8.4)
 
 
 <a name="loio3a7a0bece0d044eca59495965d8a0237__section_o5d_4t1_krb"/>


### PR DESCRIPTION
Hi, it looks like the version info here is outdated.

Is it still required to suggest people to use node 14 by default?

See https://github.com/cloudfoundry/nodejs-buildpack/releases/tag/v1.8.4 for release notes of the buildpack.