### PR TITLE
Update managed-application-router-589a239.md

### DIFF
--- a/docs/30-development/managed-application-router-589a239.md
+++ b/docs/30-development/managed-application-router-589a239.md
@@ -8,7 +8,7 @@ The managed application router is the HTML5 applications runtime capability that
 
 -   SAP Build Work Zone, advanced edition
 
--   SAP Launchpad service
+-   SAP Build Work Zone, standard edition
 
 -   SAP Cloud Portal
 
@@ -19,7 +19,7 @@ For information how to develop HTML5 applications and run them using the managed
 
 -   [Developing HTML5 Applications](https://help.sap.com/docs/HTML5_APPLICATIONS/9a1ee2f87b63473ca9fcca77158b56a5/c1b9d6facfc942e3bca664ae06387e9b.html) for **SAP Build Work Zone, advanced edition**
 
--   [Developing HTML5 Applications](https://help.sap.com/docs/Launchpad_Service/8c8e1958338140699bd4811b37b82ece/c1b9d6facfc942e3bca664ae06387e9b.html) for **SAP Build Work Zone, standard edition** 
+-   [Developing HTML5 Applications](https://help.sap.com/docs/WZ_STD/8c8e1958338140699bd4811b37b82ece/c1b9d6facfc942e3bca664ae06387e9b.html) for **SAP Build Work Zone, standard edition** 
 
 -   [Developing HTML5 Applications](https://help.sap.com/docs/Portal_Service/ad4b9f0b14b0458cad9bd27bf435637d/c1b9d6facfc942e3bca664ae06387e9b.html) for **SAP Cloud Portal**
 


### PR DESCRIPTION
As the SAP Launchpad Service is not existing anymore I updated with the new SAP Build Work Zone, standard edition service to avoid confusion. This is also matching with the links provided later in the text. There I provided the direct link to the WZ Std help page and not the redirect from the launchpad article.