### PR TITLE
API Access: New Prerequisite in case of usage on Extension Landscape

### DIFF
--- a/docs/50-administration-and-ops/access-sap-authorization-and-trust-management-service-apis-ebc9113.md
+++ b/docs/50-administration-and-ops/access-sap-authorization-and-trust-management-service-apis-ebc9113.md
@@ -30,6 +30,8 @@ To enable programmatic access to the SAP Authorization and Trust Management serv
 
 -   You have an org and a space where you can create a service instance.
 
+    If the org is located on an extension landscape, you must have logged on to the main landscape at least once as well.
+
 
 
 


### PR DESCRIPTION
It turned out that you must have logged on the main landscape at least once, if you want to provision a service of type xsuaa/apiaccess. Otherwise an error is thrown, which might be hard to understand.