### PR TITLE
change xsappContext to xsappConfig

### DIFF
--- a/docs/30-development/extension-api-of-the-application-router-a36f409.md
+++ b/docs/30-development/extension-api-of-the-application-router-a36f409.md
@@ -115,7 +115,7 @@ Starts the application router with the given options.
     -   `port` - a TCP port the application router will listen to \(string, optional\)
     -   `workingDir` - the working directory for the application router, should contain the `xs-app.json` file \(string, optional\)
     -   `extensions` - an array of extensions, each one is an object as defined in Application Router Extensions \(optional\)
-    -   `xsappContext` - An object representing the content which is usually put in `xs-app.json` file. If this property is present it will take precedence over the content of `xs-app.json`.
+    -   `xsappConfig` - An object representing the content which is usually put in `xs-app.json` file. If this property is present it will take precedence over the content of `xs-app.json`.
 
 -   `callback` - optional function with signature `callback(err)`. It is invoked when the application router has started or an error has occurred. If not provided and an error occurs \(for example the port is busy\), the application will abort.
 


### PR DESCRIPTION
I believe the docs are currently wrong, as the approuter expects a property called `xsappConfig` instead of `xs-appContext`, see line 106 here: https://www.npmjs.com/package/@sap/approuter?activeTab=code Using `xsappContext` throws an error, `xsappConfig` works.

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

