### PR TITLE
Update cloud-foundry-environment-9c7092c.md

### DIFF
--- a/docs/10-concepts/cloud-foundry-environment-9c7092c.md
+++ b/docs/10-concepts/cloud-foundry-environment-9c7092c.md
@@ -128,9 +128,13 @@ The following technical configurations are specific to SAP BTP and differ from t
 
 -   When deploying applications on SAP BTP, the maximum application package size is 1.5 GB. If your application is larger than that, the deployment fails. For more information, see [https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html](https://docs.cloudfoundry.org/devguide/deploy-apps/large-app-deploy.html)
 
+-   In the SAP BTP, Cloud Foundry environment, the hard limit for open file descriptors is 32768 (32K) per container.
+
 -   In global accounts that support the consumption-based commercial model you might see a quota limit for certain services. This is a technical limit only, not a business limit. If you need to increase this limit, report an incident to [SAP support](https://support.sap.com/en/index.html) for component BC-NEO-CIS.
 
 -   In the SAP BTP, Cloud Foundry environment, the SAP HANA database supports up to 1,000 simultaneous connections per database.
+  
+-   In the SAP BTP, Cloud Foundry environment, each app can be mapped to approximately 1000 routes (128 KB). The total length of the routing information must not exceed this limit.
 
 -   Cloud Foundry Audit Events have a retention period of 14 days. For more information on Audit Events, see [https://docs.cloudfoundry.org/running/managing-cf/audit-events.html](https://docs.cloudfoundry.org/running/managing-cf/audit-events.html).
 


### PR DESCRIPTION
Adding the BTP hard limits for open-file-descriptors and routes.

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

