### PR TITLE
Corrected Typo in  availability-zones-in-the-cloud-foundry-environment section

### DIFF
--- a/docs/10-concepts/availability-zones-in-the-cloud-foundry-environment-b6a7e11.md
+++ b/docs/10-concepts/availability-zones-in-the-cloud-foundry-environment-b6a7e11.md
@@ -30,7 +30,7 @@ The SAP BTP Cloud Foundry environment follows these recommendations to support h
 
 -   **High availability of the platform components:**
 
-    -   The building blocks of Cloud Foundry and the virtual machines on which the Cloud Foundry application instances are scheduled run in a high availability setup. Their instances are distributed across different AZs.
+    -   The building blocks of Cloud Foundry and the virtual machines on which the Cloud Foundry application instances are scheduled run in a high availability setup. These instances are distributed across different AZs.
 
     -   The technology that manages the deployment of the Cloud Foundry environment monitors the health of the platform. If there are infrastructure failures, it re-creates the faulty components.
 


### PR DESCRIPTION
Corrected typo from `their` to `these`

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

