### PR TITLE
Update to the current SapMachine Releases

### DIFF
--- a/docs/30-development/sapmachine-785d6b3.md
+++ b/docs/30-development/sapmachine-785d6b3.md
@@ -69,7 +69,7 @@ applications:
     JBP_CONFIG_SAP_MACHINE_JRE: '{ version: 11.+ }'
 ```
 
-To make the buildpack download a particular published JRE version \(for example, 11.0.13\), specify it the following way:
+To make the buildpack download a particular published JRE version \(for example, 11.0.27\), specify it the following way:
 
 ```
 ---
@@ -78,7 +78,7 @@ applications:
   ...
   env:
     JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']"
-    JBP_CONFIG_SAP_MACHINE_JRE: '{use_offline_repository: false, version: 11.0.13 }'
+    JBP_CONFIG_SAP_MACHINE_JRE: '{use_offline_repository: false, version: 11.0.27 }'
   ...
 ```
 
@@ -101,7 +101,7 @@ applications:
     JBP_CONFIG_SAP_MACHINE_JRE: '{ version: 17.+ }'
 ```
 
-To make the buildpack download a particular published JRE version \(for example, 17.0.10\), specify it the following way:
+To make the buildpack download a particular published JRE version \(for example, 17.0.15\), specify it the following way:
 
 ```
 ---
@@ -110,7 +110,7 @@ applications:
   ...
   env:
     JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']"
-    JBP_CONFIG_SAP_MACHINE_JRE: '{use_offline_repository: false, version: 17.0.10 }'
+    JBP_CONFIG_SAP_MACHINE_JRE: '{use_offline_repository: false, version: 17.0.15 }'
   ...
 ```
 
@@ -133,7 +133,7 @@ applications:
     JBP_CONFIG_SAP_MACHINE_JRE: '{ version: 21.+ }'
 ```
 
-To make the buildpack download a particular published JRE version \(for example, 21.0.2\), specify it the following way:
+To make the buildpack download a particular published JRE version \(for example, 21.0.7\), specify it the following way:
 
 ```
 ---
@@ -142,7 +142,7 @@ applications:
   ...
   env:
     JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']"
-    JBP_CONFIG_SAP_MACHINE_JRE: '{use_offline_repository: false, version: 21.0.2 }'
+    JBP_CONFIG_SAP_MACHINE_JRE: '{use_offline_repository: false, version: 21.0.7 }'
   ...
 ```
 
@@ -175,7 +175,7 @@ To specify an online JDK version \(11, 17, or 21\), use environment variable JBP
 
 ### SapMachine 11
 
-To make the buildpack download a particular published JDK version \(for example, 11.0.22\), specify it the following way:
+To make the buildpack download a particular published JDK version \(for example, 11.0.27\), specify it the following way:
 
 ```
 ---
@@ -184,7 +184,7 @@ applications:
   ...
   env:
     JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jdk.SAPMachineJDK']"
-    JBP_CONFIG_SAP_MACHINE_JDK: '{ version: 11.0.22 }'
+    JBP_CONFIG_SAP_MACHINE_JDK: '{ version: 11.0.27 }'
   ...
 ```
 
@@ -213,7 +213,7 @@ applications:
   ...
   env:
     JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jdk.SAPMachineJDK']"
-    JBP_CONFIG_SAP_MACHINE_JDK: '{ version: 17.0.10 }'
+    JBP_CONFIG_SAP_MACHINE_JDK: '{ version: 17.0.15 }'
   ...
 ```
 
@@ -242,7 +242,7 @@ applications:
   ...
   env:
     JBP_CONFIG_COMPONENTS: "jres: ['com.sap.xs.java.buildpack.jdk.SAPMachineJDK']"
-    JBP_CONFIG_SAP_MACHINE_JDK: '{ version: 21.0.2 }'
+    JBP_CONFIG_SAP_MACHINE_JDK: '{ version: 21.0.7 }'
   ...
 ```
 


### PR DESCRIPTION
Hi colleagues,
take https://github.com/SAP-docs/btp-cloud-platform/pull/268 as basis.
Based on this scroll down to the "JDK"-section and move the pinned text+code block below the un-pinned text+code block for 11, 17 and 21. (like it is already in the JRE-section on top)
Changed and added a link in the footer.

optional changes without PR:

1. The text "un-pinned"-block is not intuitve. consider changing it in something like:
To stay secure, use the latest stable version of SapMachine JDK 21. This is the **recommended** major version.    ### each line with adapted JRE/JDK and 11/17/21

2. The text "pinned"-block is not intuitve. consider changing it in something like:
In some cases, it can be helpful to pin a version of SapMachine JDK 21. However, to stay secure, you need to update this version string on your own. Because of this, SAP does **not recommend** this approach.   ### each line with adapted JRE/JDK and 11/17/21

Not yet as good as it could be, but much better than before.

Regards Christian @ SapMachine Team

pinned := the code including the whole version string (11.0.17, 17.0.15, 21.0.7)
un-pinned := the stable latest version (11.+, 17.+, 21.+)